### PR TITLE
Update vvi_from_sf.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GVI
 Type: Package
 Title: R package for computing VGVI for Spatial Raster
-Version: 1.2
+Version: 1.3
 Date: 2021-11-25
 Authors@R: 
     c(person(given = "Sebastian",

--- a/R/distance_analysis.R
+++ b/R/distance_analysis.R
@@ -77,7 +77,7 @@ distance_analysis <- function(observer, dsm_rast, dtm_rast, greenspace_rast = NU
     stop("dsm_rast must be a SpatRaster object")
   } else if (sf::st_crs(terra::crs(dsm_rast))$epsg != sf::st_crs(observer)$epsg) {
     stop("dsm_rast must have the same CRS as observer")
-  } else if(dsm_rast@ptr$res[1] != dsm_rast@ptr$res[2]) {
+  } else if(terra::res(dsm_rast)[1] != terra::res(dsm_rast)[2]) {
     stop("dsm_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
   }
   
@@ -94,7 +94,7 @@ distance_analysis <- function(observer, dsm_rast, dtm_rast, greenspace_rast = NU
       stop("greenspace_rast needs to be a SpatRaster object!")
     } else if (sf::st_crs(terra::crs(greenspace_rast))$epsg != sf::st_crs(observer)$epsg) {
       stop("greenspace_rast needs to have the same CRS as observer")
-    } else if(greenspace_rast@ptr$res[1] != greenspace_rast@ptr$res[2]) {
+    } else if (terra::res(greenspace_rast)[1] != terra::res(greenspace_rast)[2]) {
       stop("greenspace_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
     }
   }

--- a/R/resolution_analysis.R
+++ b/R/resolution_analysis.R
@@ -52,7 +52,7 @@ resolution_analysis <- function(observer, dsm_rast, dtm_rast, greenspace_rast = 
     stop("dsm_rast needs to be a SpatRaster object")
   } else if (sf::st_crs(terra::crs(dsm_rast))$epsg != sf::st_crs(observer)$epsg) {
     stop("dsm_rast needs to have the same CRS as observer")
-  } else if(dsm_rast@ptr$res[1] != dsm_rast@ptr$res[2]) {
+  } else if (terra::res(dsm_rast)[1] != terra::res(dsm_rast)[2]) {
     stop("dsm_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
   }
   
@@ -69,7 +69,7 @@ resolution_analysis <- function(observer, dsm_rast, dtm_rast, greenspace_rast = 
       stop("greenspace_rast needs to be a SpatRaster object!")
     } else if (sf::st_crs(terra::crs(greenspace_rast))$epsg != sf::st_crs(observer)$epsg) {
       stop("greenspace_rast needs to have the same CRS as observer")
-    } else if(greenspace_rast@ptr$res[1] != greenspace_rast@ptr$res[2]) {
+    } else if (terra::res(greenspace_rast)[1] != terra::res(greenspace_rast)[2]) {
       stop("greenspace_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
     }
   }

--- a/R/vgvi_from_sf.R
+++ b/R/vgvi_from_sf.R
@@ -95,7 +95,7 @@ vgvi_from_sf <- function(observer, dsm_rast, dtm_rast, greenspace_rast,
     stop("dsm_rast needs to be a SpatRaster object!")
   } else if (sf::st_crs(terra::crs(dsm_rast))$epsg != sf::st_crs(observer)$epsg) {
     stop("dsm_rast needs to have the same CRS as observer")
-  } else if(dsm_rast@ptr$res[1] != dsm_rast@ptr$res[2]) {
+  } else if (terra::res(dsm_rast)[1] != terra::res(dsm_rast)[2]) {
     stop("dsm_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
   }
   
@@ -111,7 +111,7 @@ vgvi_from_sf <- function(observer, dsm_rast, dtm_rast, greenspace_rast,
     stop("greenspace_rast needs to be a SpatRaster object!")
   } else if (sf::st_crs(terra::crs(greenspace_rast))$epsg != sf::st_crs(observer)$epsg) {
     stop("greenspace_rast needs to have the same CRS as observer")
-  } else if(dsm_rast@ptr$res[1] != dsm_rast@ptr$res[2]) {
+  } else if (terra::res(dsm_rast)[1] != terra::res(dsm_rast)[2]) {
     stop("greenspace_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
   }
   

--- a/R/viewshed.R
+++ b/R/viewshed.R
@@ -57,7 +57,7 @@ viewshed <- function(observer, dsm_rast, dtm_rast,
     stop("dsm_rast needs to be a SpatRaster object")
   } else if (sf::st_crs(terra::crs(dsm_rast))$epsg != sf::st_crs(observer)$epsg) {
     stop("dsm_rast needs to have the same CRS as observer")
-  } else if(dsm_rast@ptr$res[1] != dsm_rast@ptr$res[2]) {
+  } else if (terra::res(dsm_rast)[1] != terra::res(dsm_rast)[2]) {
     stop("dsm_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
   }
   

--- a/R/vvi_from_sf.R
+++ b/R/vvi_from_sf.R
@@ -95,7 +95,7 @@ vvi_from_sf <- function(observer, dsm_rast, dtm_rast,
     stop("dsm_rast needs to be a SpatRaster object!")
   } else if (sf::st_crs(terra::crs(dsm_rast))$epsg != sf::st_crs(observer)$epsg) {
     stop("dsm_rast needs to have the same CRS as observer")
-  } else if (dsm_rast@ptr$res[1] != dsm_rast@ptr$res[2]) {
+  } else if (terra::res(dsm_rast)[1] != terra::res(dsm_rast)[2]) {
     stop("dsm_rast: x and y resolution must be equal.\nSee https://github.com/STBrinkmann/GVI/issues/1")
   }
   


### PR DESCRIPTION
The slot that points to the C++ representation of a spatRaster object has been renamed twice in the last year in the terra package (from `@ptr` to `@pnt` to `@cpp`). It is therefor better to not explicitly refer to the slot by its name. This PR fixes the issue for the `GVI::vvi_from_sf` function.